### PR TITLE
Fix ts_crc32_section return type

### DIFF
--- a/crc.c
+++ b/crc.c
@@ -46,7 +46,7 @@ uint32_t ts_crc32(uint8_t *data, int data_size) {
 	return crc;
 }
 
-u_int32_t ts_crc32_section(struct ts_section_header *section_header) {
+uint32_t ts_crc32_section(struct ts_section_header *section_header) {
 	return ts_crc32(section_header->section_data, section_header->section_data_len);
 }
 


### PR DESCRIPTION
There's no such type u_int32_t, and the declaration uses correct uint32_t