### PR TITLE
define Service Type of Service

### DIFF
--- a/sdt_desc.c
+++ b/sdt_desc.c
@@ -93,7 +93,7 @@ static int ts_sdt_add_stream(struct ts_sdt *sdt, uint16_t service_id, uint8_t *d
 	return 1;
 }
 
-int ts_sdt_add_service_descriptor(struct ts_sdt *sdt, uint16_t service_id, uint8_t video, char *provider_name, char *service_name) {
+int ts_sdt_add_service_descriptor(struct ts_sdt *sdt, uint16_t service_id, uint8_t service_type, char *provider_name, char *service_name) {
 	char *name;
 	if (!service_name && !provider_name)
 		return 0;
@@ -109,7 +109,7 @@ int ts_sdt_add_service_descriptor(struct ts_sdt *sdt, uint16_t service_id, uint8
 	uint8_t *desc = calloc(1, desc_size);
 	desc[dpos + 0] = 0x48;					// Service descriptor
 	desc[dpos + 1] = desc_size - 2;			// -2 Because of two byte header
-	desc[dpos + 2] = video ? 0x01 : 0x02;	// DVB Table 75: Service type coding: 0x01 - digital tv, 0x02 - digital radio
+	desc[dpos + 2] = service_type;	        // DVB Table 75: Service type coding: 0x01 - digital tv, 0x02 - digital radio
 	desc[dpos + 3] = (provider_name ? strlen(provider_name) : 0);
 	dpos += 4;
 	if (!provider_name || strlen(provider_name) == 0) {

--- a/tsfuncs.h
+++ b/tsfuncs.h
@@ -238,7 +238,7 @@ int				ts_sdt_parse		(struct ts_sdt *sdt);
 void            ts_sdt_dump			(struct ts_sdt *sdt);
 void			ts_sdt_generate		(struct ts_sdt *sdt, uint8_t **ts_packets, int *num_packets);
 
-int             ts_sdt_add_service_descriptor(struct ts_sdt *sdt, uint16_t service_id, uint8_t video, char *provider_name, char *service_name);
+int             ts_sdt_add_service_descriptor(struct ts_sdt *sdt, uint16_t service_id, uint8_t service_type, char *provider_name, char *service_name);
 
 struct ts_sdt *	ts_sdt_copy			(struct ts_sdt *sdt);
 int				ts_sdt_is_same		(struct ts_sdt *sdt1, struct ts_sdt *sdt2);

--- a/tstest.c
+++ b/tstest.c
@@ -69,9 +69,10 @@ int ts_sdt_test(void) {
 
 	int i;
 	for (i=0;i<25;i++) {
-		ts_sdt_add_service_descriptor(sdt, 9,  0, "PROVIDER", "SERVICE33333333333333333333333333333333333333333333333333333333333333");
-		ts_sdt_add_service_descriptor(sdt, 13, 0, "PROddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddVIDER", "SERVICE");
-		ts_sdt_add_service_descriptor(sdt, 7,  0, "PROVIDER", "SERVICE");
+        ts_sdt_add_service_descriptor(sdt, 9,  2, "PROVIDER", "SERVICE33333333333333333333333333333333333333333333333333333333333333");
+        ts_sdt_add_service_descriptor(sdt, 13, 2, "PROddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddVIDER", "SERVICE");
+        ts_sdt_add_service_descriptor(sdt, 7,  2, "PROVIDER", "SERVICE");
+
 	}
 	ts_sdt_dump(sdt);
 


### PR DESCRIPTION
only Service Type 1 for Video and 2 for Radio is obsolete since years

actually transmitted Service Types:

- 1 Video mpeg2 SD
- 2 Radio mp2
- 10 Radio aac
- 25 Video h264 HD
- 31 Video h265 UHD
- and many more
 

It is better to let define service_type, similar to other arguments.


